### PR TITLE
Rewrite get_device function

### DIFF
--- a/project/core/service.py
+++ b/project/core/service.py
@@ -42,12 +42,20 @@ def get_device_list():
 def get_device(device_id):
     try:
         device = dbutils.get_device(device_id)
+        return device
+    except Exception as e:
+        raise WemulateException(500, "Error when getting device: " + str(e.args))
+
+
+def get_all_device_info(device_id):
+    try:
+        device = dbutils.get_device(device_id)
         active_device_profile = dbutils.get_active_profile(device)
         all_interfaces_of_device = dbutils.get_all_interfaces(device)
     except Exception as e:
         if e.args[0] == 404:
             raise e
-        raise WemulateException(500, "Error when getting device: " + str(e.args))
+        raise WemulateException(500, "Error when getting all device information: " + str(e.args))
 
     data = device.serialize()
     data['interfaces'] = [interface.serialize() for interface in all_interfaces_of_device]

--- a/project/device_ns.py
+++ b/project/device_ns.py
@@ -63,7 +63,7 @@ class DeviceInformation(Resource):
     def get(self, device_id):
         '''Fetch a Device Information and Configuration'''
         try:
-            device = wemulate_service.get_device(device_id)
+            device = wemulate_service.get_all_device_info(device_id)
         except Exception as e:
             device_ns.abort(*(e.args))
         return jsonify(device)

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -29,7 +29,7 @@ def setup_mocks(mocker):
     salt_api.get_interfaces.return_value = {'return': [{'test device name': ['eth1', 'eth2', 'eth3', 'eth4']}]}
     salt_api.get_management_ip.return_value = {'return': [{'test device name': '192.168.0.1'}]}
 
-    mocker.patch.object(utils, 'get_device')
+    mocker.patch.object(utils, 'get_all_device_info')
     mocker.patch.object(utils, 'is_device_present')
     mocker.patch.object(utils, 'get_device_list')
     mocker.patch.object(utils, 'get_active_profile')
@@ -76,7 +76,7 @@ def setup_mocks(mocker):
                           connections=[
                               connection
                           ])
-    utils.get_device.return_value = device
+    utils.get_all_device_info.return_value = device
     utils.is_device_present.return_value = False
     utils.get_device_list.return_value = [
         device
@@ -148,9 +148,9 @@ def test_get_device_list_empty(mocker):
     assert device_list == []
 
 def test_get_device_inexistent(mocker):
-    utils.get_device.side_effect=WemulateException(404, "Device with id 4 not found")
+    utils.get_all_device_info.side_effect=WemulateException(404, "Device with id 4 not found")
     try:
-        service.get_device(4)
+        service.get_all_device_info(4)
         assert False  # should not be reached
     except WemulateException as e:
         assert e.args[0] == 404
@@ -226,7 +226,7 @@ def test_add_connection(mocker):
                           interfaces=interfaces,
                           connections=[]
                           )
-    utils.get_device.return_value = device
+    utils.get_all_device_info.return_value = device
     utils.get_active_profile.return_value = profile
     utils.get_all_interfaces.return_value = interfaces
     utils.get_logical_interface.side_effect = logical_interfaces
@@ -305,7 +305,7 @@ def test_delete_connection(mocker):
                           connections=[
                               connection
                           ])
-    utils.get_device.return_value = device
+    utils.get_all_device_info.return_value = device
     utils.get_active_profile.return_value = profile
     utils.get_all_interfaces.return_value = interfaces
     utils.get_logical_interface.side_effect = logical_interfaces
@@ -360,7 +360,7 @@ def test_update_connection(mocker):
                           connections=[
                               connection
                           ])
-    utils.get_device.return_value = device
+    utils.get_all_device_info.return_value = device
     utils.get_active_profile.return_value = profile
     utils.get_all_interfaces.return_value = interfaces
     utils.get_logical_interface.side_effect = logical_interfaces


### PR DESCRIPTION
With the function `get_device`, simply the device is returned. With the function `get_all_device_info`, the device with all its additional information (connections, interfaces, profile, etc.) is returned. So the device with all its information is only called if it really used.